### PR TITLE
Added PATCH and PUT updating methods for Game

### DIFF
--- a/OnlineGameStore.BLL.Tests/Tests/GameServiceTests.cs
+++ b/OnlineGameStore.BLL.Tests/Tests/GameServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Microsoft.AspNetCore.JsonPatch;
 using OnlineGameStore.BLL.DTOs;
 using OnlineGameStore.BLL.Mapping;
 using OnlineGameStore.BLL.Services;
@@ -66,6 +67,77 @@ public class GameServiceTests
 
         Assert.NotNull(created);
         Assert.Equal(newGame.Id, created.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_GameExists_ReturnsTrue()
+    {
+        var game = _data[0];
+        var updatedGameDto = GetGameDto(
+            name: "Updated Game",
+            description: "Updated Description");
+
+        updatedGameDto.Id = game.Id;
+
+        var isUpdated = await _gameService.UpdateAsync(updatedGameDto);
+
+        Assert.True(isUpdated);
+        
+        var updatedGame = await _gameService.GetByIdAsync(game.Id);
+        
+        Assert.NotNull(updatedGame);
+        Assert.Equal(updatedGameDto.Name, updatedGame.Name);
+    }
+    
+    [Fact]
+    public async Task UpdateAsync_GameDoesNotExist_ReturnsFalse()
+    {
+        var nonExistentGameDto = GetGameDto();
+
+        var isUpdated = await _gameService.UpdateAsync(nonExistentGameDto);
+
+        Assert.False(isUpdated);
+    }
+    
+    [Fact]
+    public async Task PatchAsync_GameExists_ReturnsTrue()
+    {
+        var game = _data[0];
+        const string newName = "Patched Game Name";
+        var patchDoc = new JsonPatchDocument<GameDto>();
+        patchDoc.Replace(g => g.Name, newName);
+
+        var isPatched = await _gameService.PatchAsync(game.Id, patchDoc);
+
+        Assert.True(isPatched);
+        
+        var patchedGame = await _gameService.GetByIdAsync(game.Id);
+        
+        Assert.NotNull(patchedGame);
+        Assert.Equal(newName, patchedGame.Name);
+    }
+    
+    [Fact]
+    public async Task PatchAsync_GameDoesNotExist_ReturnsFalse()
+    {
+        var patchDoc = new JsonPatchDocument<GameDto>();
+        patchDoc.Replace(g => g.Name, "Non-existent Game");
+
+        var isPatched = await _gameService.PatchAsync(Guid.NewGuid(), patchDoc);
+
+        Assert.False(isPatched);
+    }
+    
+    [Fact]
+    public async Task PatchAsync_EmptyPatch_ReturnsTrue()
+    {
+        var game = _data[0];
+
+        var patchDoc = new JsonPatchDocument<GameDto>();
+
+        var isPatched = await _gameService.PatchAsync(game.Id, patchDoc);
+
+        Assert.True(isPatched);
     }
 
     [Fact]

--- a/OnlineGameStore.BLL.Tests/Tests/GameServiceTests.cs
+++ b/OnlineGameStore.BLL.Tests/Tests/GameServiceTests.cs
@@ -103,7 +103,9 @@ public class GameServiceTests
     public async Task PatchAsync_GameExists_ReturnsTrue()
     {
         var game = _data[0];
+
         const string newName = "Patched Game Name";
+
         var patchDoc = new JsonPatchDocument<GameDto>();
         patchDoc.Replace(g => g.Name, newName);
 
@@ -115,6 +117,10 @@ public class GameServiceTests
 
         Assert.NotNull(patchedGame);
         Assert.Equal(newName, patchedGame.Name);
+        // Check other properties remain unchanged
+        Assert.Equal(game.Description, patchedGame.Description);
+        Assert.Equal(game.Price, patchedGame.Price);
+        Assert.Equal(game.ReleaseDate, patchedGame.ReleaseDate);
     }
 
     [Fact]

--- a/OnlineGameStore.BLL.Tests/Tests/GameServiceTests.cs
+++ b/OnlineGameStore.BLL.Tests/Tests/GameServiceTests.cs
@@ -82,13 +82,13 @@ public class GameServiceTests
         var isUpdated = await _gameService.UpdateAsync(updatedGameDto);
 
         Assert.True(isUpdated);
-        
+
         var updatedGame = await _gameService.GetByIdAsync(game.Id);
-        
+
         Assert.NotNull(updatedGame);
         Assert.Equal(updatedGameDto.Name, updatedGame.Name);
     }
-    
+
     [Fact]
     public async Task UpdateAsync_GameDoesNotExist_ReturnsFalse()
     {
@@ -98,7 +98,7 @@ public class GameServiceTests
 
         Assert.False(isUpdated);
     }
-    
+
     [Fact]
     public async Task PatchAsync_GameExists_ReturnsTrue()
     {
@@ -110,13 +110,13 @@ public class GameServiceTests
         var isPatched = await _gameService.PatchAsync(game.Id, patchDoc);
 
         Assert.True(isPatched);
-        
+
         var patchedGame = await _gameService.GetByIdAsync(game.Id);
-        
+
         Assert.NotNull(patchedGame);
         Assert.Equal(newName, patchedGame.Name);
     }
-    
+
     [Fact]
     public async Task PatchAsync_GameDoesNotExist_ReturnsFalse()
     {
@@ -127,7 +127,7 @@ public class GameServiceTests
 
         Assert.False(isPatched);
     }
-    
+
     [Fact]
     public async Task PatchAsync_EmptyPatch_ReturnsTrue()
     {

--- a/OnlineGameStore.BLL/Interfaces/IService.cs
+++ b/OnlineGameStore.BLL/Interfaces/IService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace OnlineGameStore.BLL.Interfaces;
@@ -16,5 +17,6 @@ public interface IService<TEntity, TCreateDto, TReadDto, TUpdateDto>
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null);
     Task<TReadDto?> AddAsync(TCreateDto dto);
     Task<bool> UpdateAsync(TUpdateDto dto);
+    Task<bool> PatchAsync(Guid id, JsonPatchDocument<TUpdateDto> patchDoc);
     Task<bool> DeleteAsync(Guid id);
 }

--- a/OnlineGameStore.BLL/OnlineGameStore.BLL.csproj
+++ b/OnlineGameStore.BLL/OnlineGameStore.BLL.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.5" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/OnlineGameStore.BLL/Services/Service.cs
+++ b/OnlineGameStore.BLL/Services/Service.cs
@@ -49,17 +49,23 @@ public abstract class
 
     public virtual async Task<bool> UpdateAsync(TUpdateDto dto)
     {
-        if (dto is null) return false;
+        if (dto is null)
+            return false;
+
         var entity = _mapper.Map<TEntity>(dto);
+
         return await _repository.UpdateAsync(entity);
     }
 
     public virtual async Task<bool> PatchAsync(Guid id, JsonPatchDocument<TUpdateDto> patchDoc)
     {
-        if (patchDoc == null) return false;
+        if (patchDoc == null)
+            return false;
 
         var entity = await _repository.GetByIdAsync(id);
-        if (entity == null) return false;
+
+        if (entity == null)
+            return false;
 
         var dto = _mapper.Map<TUpdateDto>(entity);
 
@@ -67,8 +73,7 @@ public abstract class
 
         _mapper.Map(dto, entity);
 
-        var isUpdated = await _repository.UpdateAsync(entity);
-        return isUpdated;
+        return await _repository.UpdateAsync(entity);
     }
 
     public virtual async Task<bool> DeleteAsync(Guid id)

--- a/OnlineGameStore.BLL/Services/Service.cs
+++ b/OnlineGameStore.BLL/Services/Service.cs
@@ -40,7 +40,8 @@ public abstract class
 
     public virtual async Task<TReadDto?> AddAsync(TCreateDto dto)
     {
-        if (dto is null) return null;
+        if (dto is null)
+            return null;
 
         var entity = _mapper.Map<TEntity>(dto);
         var addedEntity = await _repository.AddAsync(entity);

--- a/OnlineGameStore.UI.Tests/ServiceMockCreators/ServiceMockCreator.cs
+++ b/OnlineGameStore.UI.Tests/ServiceMockCreators/ServiceMockCreator.cs
@@ -81,7 +81,7 @@ public abstract class ServiceMockCreator<TEntity, TCreateDto, TReadDto, TUpdateD
             {
                 var idProp = createDto.GetType().GetProperty("Id");
                 if (idProp != null &&
-                    (Guid)idProp.GetValue(createDto)! == Guid.Empty) // what if there is not proprty named Id
+                    (Guid)idProp.GetValue(createDto)! == Guid.Empty)
                 {
                     idProp.SetValue(createDto, Guid.NewGuid());
                 }
@@ -120,6 +120,7 @@ public abstract class ServiceMockCreator<TEntity, TCreateDto, TReadDto, TUpdateD
 
                 if (index == -1)
                     return false;
+
                 var entity = _data[index];
 
                 var dto = _mapper.Map<TUpdateDto>(entity);

--- a/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
+++ b/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
@@ -159,7 +159,7 @@ public class GamesControllerTests
         newGame.Name = "Updated Game Name";
         newGame.Id = gameId;
 
-        var putRequest = await _client.PutAsJsonAsync($"api/Games/{gameId}", newGame);
+        var putRequest = await _client.PutAsJsonAsync("api/Games/", newGame);
 
         Assert.Equal(HttpStatusCode.OK, putRequest.StatusCode);
 
@@ -177,29 +177,9 @@ public class GamesControllerTests
         var newGame = GetGameDto();
         newGame.Id = Guid.NewGuid();
 
-        var putRequest = await _client.PutAsJsonAsync($"api/Games/{newGame.Id}", newGame);
+        var putRequest = await _client.PutAsJsonAsync("api/Games/", newGame);
 
         Assert.Equal(HttpStatusCode.NotFound, putRequest.StatusCode);
-    }
-
-    [Fact]
-    public async Task UpdateAsync_GameIdMismatch_ReturnsBadRequest()
-    {
-        var newGame = GetGameDto();
-
-        var postRequest = await _client.PostAsJsonAsync("api/Games", newGame);
-
-        Assert.Equal(HttpStatusCode.Created, postRequest.StatusCode);
-
-        var game = await postRequest.Content.ReadFromJsonAsync<GameDto>();
-        var gameId = game!.Id;
-
-        newGame.Name = "Updated Game Name";
-        newGame.Id = Guid.NewGuid();
-
-        var putRequest = await _client.PutAsJsonAsync($"api/Games/{gameId}", newGame);
-
-        Assert.Equal(HttpStatusCode.BadRequest, putRequest.StatusCode);
     }
 
     private GameDto GetGameDto(

--- a/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
+++ b/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
@@ -204,8 +204,10 @@ public class GamesControllerTests
         var created = await postResponse.Content.ReadFromJsonAsync<GameDto>();
         var id = created!.Id;
 
+        const string newName = "Updated Game Name";
+
         var patchDoc = new JsonPatchDocument<GameDto>();
-        patchDoc.Replace(g => g.Name, "Updated Game Name");
+        patchDoc.Replace(g => g.Name, newName);
 
         var json = JsonConvert.SerializeObject(patchDoc);
         var content = new StringContent(json, Encoding.UTF8, "application/json-patch+json");
@@ -216,7 +218,7 @@ public class GamesControllerTests
         var getResponse = await _client.GetAsync($"api/Games/{id}");
         var updated = await getResponse.Content.ReadFromJsonAsync<GameDto>();
 
-        Assert.Equal("Updated Game Name", updated!.Name);
+        Assert.Equal(newName, updated!.Name);
     }
 
     [Fact]
@@ -225,8 +227,10 @@ public class GamesControllerTests
         var newGame = GetGameDto();
         newGame.Id = Guid.NewGuid();
 
+        const string newName = "Updated Game Name";
+
         var patchDoc = new JsonPatchDocument<GameDto>();
-        patchDoc.Replace(g => g.Name, "Updated Game Name");
+        patchDoc.Replace(g => g.Name, newName);
 
         var json = JsonConvert.SerializeObject(patchDoc);
         var content = new StringContent(json, Encoding.UTF8, "application/json-patch+json");

--- a/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
+++ b/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
@@ -228,7 +228,10 @@ public class GamesControllerTests
         var patchDoc = new JsonPatchDocument<GameDto>();
         patchDoc.Replace(g => g.Name, "Updated Game Name");
 
-        var patchRequest = await _client.PatchAsJsonAsync($"api/Games/{newGame.Id}", patchDoc);
+        var json = JsonConvert.SerializeObject(patchDoc);
+        var content = new StringContent(json, Encoding.UTF8, "application/json-patch+json");
+
+        var patchRequest = await _client.PatchAsync($"api/Games/{newGame.Id}", content);
 
         Assert.Equal(HttpStatusCode.NotFound, patchRequest.StatusCode);
     }

--- a/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
+++ b/OnlineGameStore.UI.Tests/Tests/GamesControllerTests.cs
@@ -144,6 +144,64 @@ public class GamesControllerTests
         Assert.Equal(HttpStatusCode.NotFound, secondDeleteRequest.StatusCode);
     }
 
+    [Fact]
+    public async Task UpdateAsync_GameExists_ReturnsUpdatedGame()
+    {
+        var newGame = GetGameDto();
+
+        var postRequest = await _client.PostAsJsonAsync("api/Games", newGame);
+
+        Assert.Equal(HttpStatusCode.Created, postRequest.StatusCode);
+
+        var game = await postRequest.Content.ReadFromJsonAsync<GameDto>();
+        var gameId = game!.Id;
+
+        newGame.Name = "Updated Game Name";
+        newGame.Id = gameId;
+
+        var putRequest = await _client.PutAsJsonAsync($"api/Games/{gameId}", newGame);
+
+        Assert.Equal(HttpStatusCode.OK, putRequest.StatusCode);
+
+        var getRequest = await _client.GetAsync("api/Games/" + gameId);
+
+        var updatedGame = await getRequest.Content.ReadFromJsonAsync<GameDto>();
+
+        Assert.NotNull(updatedGame);
+        Assert.Equal(newGame.Name, updatedGame.Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_GameDoesNotExist_ReturnsNotFound()
+    {
+        var newGame = GetGameDto();
+        newGame.Id = Guid.NewGuid();
+
+        var putRequest = await _client.PutAsJsonAsync($"api/Games/{newGame.Id}", newGame);
+
+        Assert.Equal(HttpStatusCode.NotFound, putRequest.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_GameIdMismatch_ReturnsBadRequest()
+    {
+        var newGame = GetGameDto();
+
+        var postRequest = await _client.PostAsJsonAsync("api/Games", newGame);
+
+        Assert.Equal(HttpStatusCode.Created, postRequest.StatusCode);
+
+        var game = await postRequest.Content.ReadFromJsonAsync<GameDto>();
+        var gameId = game!.Id;
+
+        newGame.Name = "Updated Game Name";
+        newGame.Id = Guid.NewGuid();
+
+        var putRequest = await _client.PutAsJsonAsync($"api/Games/{gameId}", newGame);
+
+        Assert.Equal(HttpStatusCode.BadRequest, putRequest.StatusCode);
+    }
+
     private GameDto GetGameDto(
         string name = "Test Game",
         string description = "Test Description",

--- a/OnlineGameStore.UI/Controllers/GamesController.cs
+++ b/OnlineGameStore.UI/Controllers/GamesController.cs
@@ -86,6 +86,10 @@ public class GamesController : ControllerBase
         return NoContent();
     }
 
+    /// <summary>
+    /// Updates all game fields.
+    /// </summary>
+    /// <param name="gameDto">New Game entity with existing ID</param>
     [HttpPut]
     public async Task<IActionResult> UpdatePutAsync([FromBody] GameDto gameDto)
     {
@@ -104,6 +108,28 @@ public class GamesController : ControllerBase
         return Ok();
     }
 
+    /// <summary>
+    /// Updates only specified game fields.
+    /// </summary>
+    /// <remarks>
+    /// If you want to update game name and price, you can send a JSON object like this:
+    /// 
+    ///     [
+    ///         {
+    ///             "path": "/name",
+    ///             "op": "replace",
+    ///             "value": "game"
+    ///         },
+    ///         {
+    ///             "path": "/price",
+    ///             "op": "replace",
+    ///             "value": 5
+    ///         }
+    ///     ]
+    /// 
+    /// </remarks>
+    /// <param name="id">ID of a Game entity to update</param>
+    /// <param name="patchDoc">JSON object that contains fields to be updated and new values</param>
     [HttpPatch("{id:guid}")]
     public async Task<IActionResult> UpdatePatchAsync(Guid id, [FromBody] JsonPatchDocument<GameDto> patchDoc)
     {

--- a/OnlineGameStore.UI/Controllers/GamesController.cs
+++ b/OnlineGameStore.UI/Controllers/GamesController.cs
@@ -84,4 +84,27 @@ public class GamesController : ControllerBase
 
         return NoContent();
     }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] GameDto? gameDto)
+    {
+        if (gameDto == null)
+        {
+            return BadRequest("Game data is required.");
+        }
+
+        if (id != gameDto.Id)
+        {
+            return BadRequest("Game ID mismatch.");
+        }
+
+        var isUpdated = await _service.UpdateAsync(gameDto);
+
+        if (!isUpdated)
+        {
+            return NotFound();
+        }
+
+        return Ok();
+    }
 }

--- a/OnlineGameStore.UI/Controllers/GamesController.cs
+++ b/OnlineGameStore.UI/Controllers/GamesController.cs
@@ -103,14 +103,14 @@ public class GamesController : ControllerBase
 
         return Ok();
     }
-    
+
     [HttpPatch("{id:guid}")]
     public async Task<IActionResult> UpdatePatchAsync(Guid id, [FromBody] JsonPatchDocument<GameDto> patchDoc)
     {
         if (patchDoc == null) return BadRequest("Patch document is required.");
 
         var result = await _service.PatchAsync(id, patchDoc);
-        
+
         if (!result) return NotFound();
         return Ok();
     }

--- a/OnlineGameStore.UI/Controllers/GamesController.cs
+++ b/OnlineGameStore.UI/Controllers/GamesController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using OnlineGameStore.BLL.DTOs;
 using OnlineGameStore.BLL.Interfaces;
@@ -86,7 +87,7 @@ public class GamesController : ControllerBase
     }
 
     [HttpPut]
-    public async Task<IActionResult> UpdatePutAsync([FromBody] GameDto? gameDto)
+    public async Task<IActionResult> UpdatePutAsync([FromBody] GameDto gameDto)
     {
         if (gameDto == null)
         {
@@ -100,6 +101,17 @@ public class GamesController : ControllerBase
             return NotFound();
         }
 
+        return Ok();
+    }
+    
+    [HttpPatch("{id:guid}")]
+    public async Task<IActionResult> UpdatePatchAsync(Guid id, [FromBody] JsonPatchDocument<GameDto> patchDoc)
+    {
+        if (patchDoc == null) return BadRequest("Patch document is required.");
+
+        var result = await _service.PatchAsync(id, patchDoc);
+        
+        if (!result) return NotFound();
         return Ok();
     }
 }

--- a/OnlineGameStore.UI/Controllers/GamesController.cs
+++ b/OnlineGameStore.UI/Controllers/GamesController.cs
@@ -85,17 +85,12 @@ public class GamesController : ControllerBase
         return NoContent();
     }
 
-    [HttpPut("{id:guid}")]
-    public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] GameDto? gameDto)
+    [HttpPut]
+    public async Task<IActionResult> UpdatePutAsync([FromBody] GameDto? gameDto)
     {
         if (gameDto == null)
         {
             return BadRequest("Game data is required.");
-        }
-
-        if (id != gameDto.Id)
-        {
-            return BadRequest("Game ID mismatch.");
         }
 
         var isUpdated = await _service.UpdateAsync(gameDto);

--- a/OnlineGameStore.UI/OnlineGameStore.UI.csproj
+++ b/OnlineGameStore.UI/OnlineGameStore.UI.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
   </ItemGroup>
 

--- a/OnlineGameStore.UI/Program.cs
+++ b/OnlineGameStore.UI/Program.cs
@@ -21,7 +21,7 @@ builder.Services.AddSwaggerGen(options =>
     options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
 });
 
-builder.Services.AddControllers();
+builder.Services.AddControllers().AddNewtonsoftJson();
 builder.Services.AddDalServices(builder.Configuration);
 builder.Services.AddBllServices();
 


### PR DESCRIPTION
### Added two endpoints in `GamesController` for updating Game entities via `PUT` and `PATCH`

---

### User stories:
   - Update a game (put)
   - Update a game (patch)

### Changes made:
   - Added packages to the project for JsonDe-/Serialization
   - Added `PatchAsync` method for `IService` interface
   - Added mock for `PatchAsync` method in `ServiceMockCreator`
   - Implemented `PatchAsync` method in `Service` generic class
   - Implemented `UpdatePutAsync` and `UpdatePatchAsync` methods in `GamesController` class
   - Covered both methods with tests
   - Covered `UpdateAsync` and `PatchAsync` GameService methods with tests

### Notes:
   1. Patch implementation:
      - The patch method uses the `Newtonsoft.Json` package for JSON operations. To update some entity fields, you need to explicitly specify the field, new value, and action (usually replace or add)
      - Example for Game is below
      ```json
      [
       {
        "path": "/name",
        "op": "replace",
        "value": "game"
       },
       {
        "path": "/price",
        "op": "replace",
        "value": 5
       }
      ]
      ```