### PR TITLE
Added background service for Roles seeding

### DIFF
--- a/OnlineGameStore.UI/Program.cs
+++ b/OnlineGameStore.UI/Program.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.OpenApi.Models;
 using OnlineGameStore.BLL;
 using OnlineGameStore.DAL;
+using OnlineGameStore.UI.Services;
 
 const string apiVersion = "1.0.0";
 const string documentName = "online-game-store-api";
@@ -24,6 +25,7 @@ builder.Services.AddSwaggerGen(options =>
 builder.Services.AddControllers().AddNewtonsoftJson();
 builder.Services.AddDalServices(builder.Configuration);
 builder.Services.AddBllServices();
+builder.Services.AddHostedService<RoleSeederService>();
 
 var app = builder.Build();
 

--- a/OnlineGameStore.UI/Services/RoleSeederService.cs
+++ b/OnlineGameStore.UI/Services/RoleSeederService.cs
@@ -1,9 +1,49 @@
+using Microsoft.EntityFrameworkCore;
+using OnlineGameStore.DAL.DBContext;
+using OnlineGameStore.DAL.Entities;
+
 namespace OnlineGameStore.UI.Services;
 
 public class RoleSeederService : BackgroundService
 {
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    private readonly IServiceProvider _serviceProvider;
+
+    private static readonly List<Role> Roles =
+    [
+        new Role { Name = "Admin", Description = "Administrator with full access" },
+        new Role { Name = "User", Description = "Regular user with limited access" },
+        new Role { Name = "Guest", Description = "Guest user with minimal access" }
+    ];
+
+    public RoleSeederService(IServiceProvider serviceProvider)
     {
-        throw new NotImplementedException();
+        _serviceProvider = serviceProvider;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OnlineGameStoreDbContext>();
+
+        try
+        {
+            if (!await dbContext.Roles.AnyAsync(stoppingToken))
+            {
+                await dbContext.Roles.AddRangeAsync(Roles, stoppingToken);
+                await dbContext.SaveChangesAsync(stoppingToken);
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            Console.WriteLine("Role seeding operation was canceled.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error seeding roles: {ex.Message}");
+        }
+        finally
+        {
+            await dbContext.DisposeAsync();
+        }
     }
 }

--- a/OnlineGameStore.UI/Services/RoleSeederService.cs
+++ b/OnlineGameStore.UI/Services/RoleSeederService.cs
@@ -1,0 +1,9 @@
+namespace OnlineGameStore.UI.Services;
+
+public class RoleSeederService : BackgroundService
+{
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/OnlineGameStore.UI/Services/RoleSeederService.cs
+++ b/OnlineGameStore.UI/Services/RoleSeederService.cs
@@ -40,6 +40,7 @@ public class RoleSeederService : BackgroundService
         catch (Exception ex)
         {
             Console.WriteLine($"Error seeding roles: {ex.Message}");
+            throw;
         }
         finally
         {


### PR DESCRIPTION
### This PR adds a background service for seeding default Roles if the database is empty

### User stories:
1. Seed Default Roles in DB on Application Startup

### Changes made:
 - Created `RoleSeederService` class with implementation
 - `RoleSeederService` is registered in the `Program.cs` and works