### PR TITLE
Added background service for Admin user seeding

### DIFF
--- a/OnlineGameStore.UI/OnlineGameStore.UI.csproj
+++ b/OnlineGameStore.UI/OnlineGameStore.UI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -7,6 +7,7 @@
     <RootNamespace>OnlineGameStore.UI</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <UserSecretsId>ad9c1817-0526-486b-84a3-d6659d6f7c44</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OnlineGameStore.UI/Program.cs
+++ b/OnlineGameStore.UI/Program.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.OpenApi.Models;
 using OnlineGameStore.BLL;
 using OnlineGameStore.DAL;
+using OnlineGameStore.UI.Services;
 
 const string apiVersion = "1.0.0";
 const string documentName = "online-game-store-api";
@@ -24,6 +25,8 @@ builder.Services.AddSwaggerGen(options =>
 builder.Services.AddControllers().AddNewtonsoftJson();
 builder.Services.AddDalServices(builder.Configuration);
 builder.Services.AddBllServices();
+
+builder.Services.AddHostedService<AdminSeederService>();
 
 var app = builder.Build();
 

--- a/OnlineGameStore.UI/Services/AdminSeederService.cs
+++ b/OnlineGameStore.UI/Services/AdminSeederService.cs
@@ -17,7 +17,7 @@ public class AdminSeederService : BackgroundService
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         using var scope = _serviceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<OnlineGameStoreDbContext>();
@@ -25,7 +25,7 @@ public class AdminSeederService : BackgroundService
         if (dbContext == null)
             throw new ArgumentNullException(nameof(dbContext));
 
-        if (await dbContext.Users.AnyAsync(stoppingToken))
+        if (await dbContext.Users.AnyAsync(cancellationToken))
             return;
 
         var configuration = _serviceProvider.GetRequiredService<IConfiguration>();
@@ -41,7 +41,7 @@ public class AdminSeederService : BackgroundService
             return;
         }
 
-        var adminRole = await dbContext.Roles.FirstOrDefaultAsync(r => r.Name == "Admin", stoppingToken);
+        var adminRole = await dbContext.Roles.FirstOrDefaultAsync(r => r.Name == "Admin", cancellationToken);
 
         if (adminRole == null) // In case our Role seeding fails or starts later
         {
@@ -55,7 +55,7 @@ public class AdminSeederService : BackgroundService
             try
             {
                 dbContext.Roles.Add(newAdminRole);
-                await dbContext.SaveChangesAsync(stoppingToken);
+                await dbContext.SaveChangesAsync(cancellationToken);
             }
             catch (Exception ex)
             {
@@ -79,7 +79,7 @@ public class AdminSeederService : BackgroundService
         try
         {
             dbContext.Users.Add(adminUser);
-            await dbContext.SaveChangesAsync(stoppingToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
             dbContext.UserRoles.Add(new UserRole
             {
@@ -87,7 +87,7 @@ public class AdminSeederService : BackgroundService
                 RoleId = adminRole.Id
             });
 
-            await dbContext.SaveChangesAsync(stoppingToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/OnlineGameStore.UI/Services/AdminSeederService.cs
+++ b/OnlineGameStore.UI/Services/AdminSeederService.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using OnlineGameStore.DAL.DBContext;

--- a/OnlineGameStore.UI/Services/AdminSeederService.cs
+++ b/OnlineGameStore.UI/Services/AdminSeederService.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using OnlineGameStore.DAL.DBContext;
+using OnlineGameStore.DAL.Entities;
+
+namespace OnlineGameStore.UI.Services;
+
+public class AdminSeederService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public AdminSeederService(IServiceProvider serviceProvider)
+
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OnlineGameStoreDbContext>();
+
+        if (dbContext == null)
+            throw new ArgumentNullException(nameof(dbContext));
+
+        if (await dbContext.Users.AnyAsync(stoppingToken))
+            return;
+
+        var configuration = _serviceProvider.GetRequiredService<IConfiguration>();
+
+        var adminUsername = configuration["AdminSeed:Username"];
+        var adminEmail = configuration["AdminSeed:Email"];
+        var adminPassword = configuration["AdminSeed:Password"];
+
+        if (string.IsNullOrWhiteSpace(adminEmail) || string.IsNullOrWhiteSpace(adminPassword) ||
+            string.IsNullOrWhiteSpace(adminUsername))
+        {
+            Console.WriteLine("Admin seed data missing from configuration.");
+            return;
+        }
+
+        var adminRole = await dbContext.Roles.FirstOrDefaultAsync(r => r.Name == "Admin", stoppingToken);
+
+        if (adminRole == null) // In case our Role seeding fails or starts later
+        {
+            Console.WriteLine("Admin role not found in the database.");
+
+            var newAdminRole = new Role
+            {
+                Name = "Admin",
+                Description = "Administrator role with full permissions"
+            };
+            try
+            {
+                dbContext.Roles.Add(newAdminRole);
+                await dbContext.SaveChangesAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to create admin role: {ex.Message}");
+                return;
+            }
+
+            adminRole = newAdminRole;
+        }
+
+        var adminUser = new User
+        {
+            Email = adminEmail,
+            UserName = adminUsername,
+            PasswordHash = Encoding.Default.GetString(SHA256.HashData(Encoding.Default.GetBytes(adminPassword)))
+        };
+
+        try
+        {
+            dbContext.Users.Add(adminUser);
+            await dbContext.SaveChangesAsync(stoppingToken);
+
+            dbContext.UserRoles.Add(new UserRole
+            {
+                UserId = adminUser.Id,
+                RoleId = adminRole.Id
+            });
+
+            await dbContext.SaveChangesAsync(stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to seed admin user: {ex.Message}");
+            return;
+        }
+
+        Console.WriteLine($"Seeded default admin user: {adminEmail}");
+    }
+}

--- a/OnlineGameStore.UI/Services/AdminSeederService.cs
+++ b/OnlineGameStore.UI/Services/AdminSeederService.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using OnlineGameStore.DAL.DBContext;
 using OnlineGameStore.DAL.Entities;
@@ -65,12 +66,15 @@ public class AdminSeederService : BackgroundService
             adminRole = newAdminRole;
         }
 
+        var hasher = new PasswordHasher<User>();
+
         var adminUser = new User
         {
             Email = adminEmail,
-            UserName = adminUsername,
-            PasswordHash = Encoding.Default.GetString(SHA256.HashData(Encoding.Default.GetBytes(adminPassword)))
+            UserName = adminUsername
         };
+
+        adminUser.PasswordHash = hasher.HashPassword(adminUser, adminPassword);
 
         try
         {

--- a/OnlineGameStore.UI/Services/AdminSeederService.cs
+++ b/OnlineGameStore.UI/Services/AdminSeederService.cs
@@ -79,8 +79,6 @@ public class AdminSeederService : BackgroundService
         try
         {
             dbContext.Users.Add(adminUser);
-            await dbContext.SaveChangesAsync(cancellationToken);
-
             dbContext.UserRoles.Add(new UserRole
             {
                 UserId = adminUser.Id,


### PR DESCRIPTION
### This PR adds a background service for seeding the default Admin user if the database is empty

### User stories:
1. Seed Default Admin User

### Changes made:
 - Created `AdminSeederService` class with implementation
 - `AdminSeederService` is registered in the `Program.cs` and works

### Notes:
- Important: For secure data extraction, I used `dotnet user-secrets`
  Here are simple steps:
  1. Select `UI` folder and enter `dotnet user-secrets init` in the console, this should add ID in the `.csproj` file
  2. Add secrets using `dotnet user-secrets set "AdminSeed:{Username/Password/Email}" "{CorrespondingValue}"`
  3. Verify values with `dotnet user-secrets list`
  
  Feel free to propose a better solution if you have any!