### PR TITLE
Nullable Genre/Platform DTOs in GameDTO

### DIFF
--- a/OnlineGameStore.BLL/DTOs/Games/GameDetailedDto.cs
+++ b/OnlineGameStore.BLL/DTOs/Games/GameDetailedDto.cs
@@ -1,6 +1,7 @@
 ﻿using OnlineGameStore.BLL.DTOs.Genres;
 using OnlineGameStore.BLL.DTOs.Platforms;
 using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
 
 namespace OnlineGameStore.BLL.DTOs.Games;
 
@@ -26,9 +27,10 @@ public class GameDetailedDto
     public DateTime ReleaseDate { get; set; }
 
     [Required]
-    public ICollection<GenreBasicDto> GenreDtos { get; set; } = new List<GenreBasicDto>();
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public ICollection<GenreBasicDto>? GenreDtos { get; set; }
 
     [Required]
-    public ICollection<PlatformBasicDto> PlatformDtos { get; set; } = new List<PlatformBasicDto>();
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public ICollection<PlatformBasicDto>? PlatformDtos { get; set; }
 }
-

--- a/OnlineGameStore.BLL/DTOs/Games/GameDto.cs
+++ b/OnlineGameStore.BLL/DTOs/Games/GameDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
 
 namespace OnlineGameStore.BLL.DTOs.Games;
 
@@ -16,7 +17,9 @@ public class GameDto
     [Required]
     public DateTime ReleaseDate { get; set; }
     [Required]
-    public ICollection<Guid> GenresIds { get; set; } = new List<Guid>();
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public ICollection<Guid>? GenresIds { get; set; } 
     [Required]
-    public ICollection<Guid> PlatformsIds { get; set; } = new List<Guid>();
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public ICollection<Guid>? PlatformsIds { get; set; }
 }

--- a/OnlineGameStore.BLL/Services/GameService.cs
+++ b/OnlineGameStore.BLL/Services/GameService.cs
@@ -36,9 +36,18 @@ public class GameService : Service<Game, GameCreateDto, GameDto, GameDto, GameDe
                 opts.Items["IncludePlatforms"] = includePlatforms;
             });
 
+        var items = mappedItems.Select(game =>
+        {
+            if (!includeGenres)
+                game.GenreDtos = null;
+            if (!includePlatforms)
+                game.PlatformDtos = null;
+            return game;
+        });
+
         return new PaginatedResponse<GameDetailedDto>
         {
-            Items = mappedItems,
+            Items = items,
             Pagination = paginatedResponse.Pagination
         };
     }


### PR DESCRIPTION
User Story: [Remove empty GenreDtos/PlatformDtos if include is not specified](https://trello.com/c/rY6GB1Fx)

- Platform and Genre-related fields are now nullable in GameDTO and GameDetailedDTO
- If include is not specified, then GameService manually makes that field null

This is made that way because EF Core implicitly generates an empty list even after making Platforms and Genres fields explicitly null